### PR TITLE
Add Micro Front-Ends: Webpack Manifest link to tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [Microservices in the frontend with BFFs providing their own bundles and API.](https://github.com/dactylographsy/browser-dactylographsy)
 - [Simulate a micro frontend project using NodeJS, React and NGinx Reverse Proxy in Alpine Docker images](https://github.com/willmendesneto/micro-frontend-pages)
 - [manfredsteyer/Angular_MicroApps_Different_Technologies](https://github.com/manfredsteyer/Angular_MicroApps_Different_Technologies)
+- [Micro Front-Ends: Webpack Manifest](https://medium.embengineering.com/micro-front-ends-webpack-manifest-b05fc63a0d53)
 
 ## Experience Reports
 


### PR DESCRIPTION
## What it does
- adds additional article to tooling section from Emmanuel Morales regarding a pattern for micro-frontends using webpack manifests loaded over ajax

Note: I wasn't clear on the ordering of the links so simply added to the bottom of tooling list. If there's a preferable alternative approach, please let me know. Thanks for starting this list as it's of great interest to me!