### PR TITLE
Add voltranjs for frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [Podium](https://podium-lib.io) - Easy server side composition of microfrontends.
 - [Nuz is an open-source project, the runtime package manager for web platform.](https://docs.nuz.app/introduction/overview) - WIP.
 - [Luigi - technology agnostic, open-source micro-frontend framework](https://luigi-project.io/)
+- [VoltranJS](https://github.com/hepsiburada/VoltranJS)
 
 ### Platforms
 - [Mashroom Server](https://www.mashroom-server.com)


### PR DESCRIPTION
I added voltranjs. Voltran is a micro frontends framework which is developed by Hepsiburada Technology Team. Micro frontends help cross functional teams to make end-to-end and independent developments and deployments.